### PR TITLE
get_property: early return when property not found

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -287,8 +287,6 @@ fn get_hostfunc(
                  return_value_data: i32,
                  return_value_size: i32|
                  -> i32 {
-                    println!("[vm->host] proxy_get_property({path_data}, {path_size})");
-
                     let mem = match caller.get_export("memory") {
                         Some(Extern::Memory(mem)) => mem,
                         _ => {

--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -321,7 +321,7 @@ fn get_hostfunc(
                         Some(expect_property_value) => expect_property_value,
                         None => {
                             println!(
-                                "[vm->host] proxy_get_property(path_data, path_size) -> NotFound, status: {:?}",
+                                "[vm->host] proxy_get_property(...) -> NotFound, status: {:?}",
                                 get_status()
                             );
                             assert_ne!(get_status(), ExpectStatus::Failed);
@@ -360,11 +360,8 @@ fn get_hostfunc(
                             .copy_from_slice(&(property_value_add as u32).to_le_bytes());
                     }
 
-                    println!(
-                        "[vm->host] proxy_get_property(path_data, path_size) -> (...) status: {:?}",
-                        get_status()
-                    );
-                    println!("[vm<-host] proxy_get_property(...) -> (return_value_data, return_value_size) return: {:?}", Status::Ok);
+                    println!("[vm<-host] proxy_get_property(...) -> (return_value_data={property_value:?}, return_value_size={}) return: {:?}",
+                        property_value.len(), get_status());
                     assert_ne!(get_status(), ExpectStatus::Failed);
                     return Status::Ok as i32;
                 },

--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -319,7 +319,14 @@ fn get_hostfunc(
                         .get_expect_get_property(path_raw)
                     {
                         Some(expect_property_value) => expect_property_value,
-                        None => vec![],
+                        None => {
+                            println!(
+                                "[vm->host] proxy_get_property(path_data, path_size) -> NotFound, status: {:?}",
+                                get_status()
+                            );
+                            assert_ne!(get_status(), ExpectStatus::Failed);
+                            return Status::NotFound as i32;
+                        }
                     };
 
                     unsafe {
@@ -832,7 +839,7 @@ fn get_hostfunc(
                             .staged
                             .get_expect_set_header_map_pairs(map_type, header_map_ptr);
                     }
-                    println!("[vm->host] proxy_set_header_map_pairs(map_type={}, map_data, map_size) status: {:?}", 
+                    println!("[vm->host] proxy_set_header_map_pairs(map_type={}, map_data, map_size) status: {:?}",
                         map_type, get_status()
                     );
                     println!(
@@ -938,10 +945,10 @@ fn get_hostfunc(
                         return_value_size_ptr
                             .copy_from_slice(&(string_value.len() as u32).to_le_bytes());
 
-                        println!("[vm->host] proxy_get_header_map_value(map_type={}, key_data={}, key_size={}) -> (...) status: {:?}", 
+                        println!("[vm->host] proxy_get_header_map_value(map_type={}, key_data={}, key_size={}) -> (...) status: {:?}",
                             map_type, string_key, key_size, get_status()
                         );
-                        println!("[vm<-host] proxy_get_header_map_value(...) -> (return_value_data={}, return_value_size={}) return: {:?}", 
+                        println!("[vm<-host] proxy_get_header_map_value(...) -> (return_value_data={}, return_value_size={}) return: {:?}",
                             string_value, string_value.len(), Status::Ok
                         );
                     }


### PR DESCRIPTION
When property is not found, the testing framework was returning `Status::Ok` with empty array.

Proxy-wasm-sdk library is reading that as correct return value and returning `Ok(Some(Bytes))`. The correct branch should be `Status::NotFound => Ok(None),` when the property is not found. So, fixing the return value from the testing framework.
Here https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/v0.2.1/src/hostcalls.rs#L396-L422

```rust
pub fn get_property(path: Vec<&str>) -> Result<Option<Bytes>, Status> {
    let serialized_path = utils::serialize_property_path(path);
    let mut return_data: *mut u8 = null_mut();
    let mut return_size: usize = 0;
    unsafe {
        match proxy_get_property(
            serialized_path.as_ptr(),
            serialized_path.len(),
            &mut return_data,
            &mut return_size,
        ) {
            Status::Ok => {
                if !return_data.is_null() {
                    Ok(Some(Vec::from_raw_parts(
                        return_data,
                        return_size,
                        return_size,
                    )))
                } else {
                    Ok(None)
                }
            }
            Status::NotFound => Ok(None),
            status => panic!("unexpected status: {}", status as u32),
        }
    }
}
```