### PR TITLE
proxy_get_header_map_value: early return when header not found

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -901,9 +901,22 @@ fn get_hostfunc(
                             {
                                 Some(expect_string_value) => expect_string_value,
                                 None => {
-                                    match HOST.lock().unwrap().staged.get_header_map_value(map_type, &string_key) {
+                                    match HOST
+                                        .lock()
+                                        .unwrap()
+                                        .staged
+                                        .get_header_map_value(map_type, &string_key)
+                                    {
                                         Some(host_string_value) => host_string_value,
-                                        None => panic!("Error: proxy_get_header_map_value | no header map value for key {}", string_key)}
+                                        None => {
+                                            println!(
+                                                "[vm->host] proxy_get_header_map_value(map_type={}, key_data={}) -> NotFound, status: {:?}",
+                                                map_type, string_key, get_status()
+                                            );
+                                            assert_ne!(get_status(), ExpectStatus::Failed);
+                                            return Status::NotFound as i32;
+                                        }
+                                    }
                                 }
                             };
                             (string_key.to_string(), string_value)


### PR DESCRIPTION
### What
When header was not found, the testing framework was panic'ing. 

Returning `Status::NotFound` instead as expected by [Proxy-wasm-sdk library](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/96f791aaf86ef95326022280be987f19635eeaa5/src/hostcalls.rs#L275).

```rust
pub fn get_map_value_bytes(map_type: MapType, key: &str) -> Result<Option<Bytes>, Status> {
    let mut return_data: *mut u8 = null_mut();
    let mut return_size: usize = 0;
    unsafe {
        match proxy_get_header_map_value(
            map_type,
            key.as_ptr(),
            key.len(),
            &mut return_data,
            &mut return_size,
        ) {
            Status::Ok => {
                if !return_data.is_null() {
                    Ok(Some(Vec::from_raw_parts(
                        return_data,
                        return_size,
                        return_size,
                    )))
                } else {
                    Ok(None)
                }
            }
            Status::NotFound => Ok(None),
            status => panic!("unexpected status: {}", status as u32),
        }
    }
}
```