### PR TITLE
Deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "9.0.3"
+wasmtime = { version = "9.0.3" , default-features = false, features = ["cranelift"] }
 anyhow = "1.0.31"
 lazy_static = "1.4.0"
 more-asserts = "0.2.1"

--- a/examples/http_auth_random.rs
+++ b/examples/http_auth_random.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
     http_auth_random
         .call_proxy_on_http_call_response(http_context, 0, 0, buffer_data.len() as i32, 0)
         .expect_get_buffer_bytes(Some(BufferType::HttpCallResponseBody))
-        .returning(Some(buffer_data))
+        .returning(Some(buffer_data.as_bytes()))
         .expect_send_local_response(
             Some(403),
             Some("Access forbidden.\n"),


### PR DESCRIPTION
We can't have `wat` (default feature otherwise) enabled, as it eventually pulls in a dependency that's not buildable on `<1.76`... 