### PR TITLE
Support for wasi

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -296,13 +296,17 @@ fn get_hostfunc(
                         }
                     };
 
-                    let malloc = match caller.get_export("malloc") {
+                    // Try proxy_on_memory_allocate first (proxy-wasm ABI), then fall back to malloc
+                    let malloc = match caller.get_export("proxy_on_memory_allocate") {
                         Some(Extern::Func(func)) => func,
-                        _ => {
-                            println!("Error: proxy_get_property cannot get export \"malloc\"");
-                            println!("[vm<-host] proxy_get_property(...) -> (return_value_data, return_value_size) return: {:?}", Status::InternalFailure);
-                            return Status::InternalFailure as i32;
-                        }
+                        _ => match caller.get_export("malloc") {
+                            Some(Extern::Func(func)) => func,
+                            _ => {
+                                println!("Error: proxy_get_property cannot get export \"proxy_on_memory_allocate\" or \"malloc\"");
+                                println!("[vm<-host] proxy_get_property(...) -> (return_value_data, return_value_size) return: {:?}", Status::InternalFailure);
+                                return Status::InternalFailure as i32;
+                            }
+                        },
                     };
 
                     let path_raw = read_bytes(&caller, mem, path_data, path_size).unwrap();
@@ -734,15 +738,19 @@ fn get_hostfunc(
                         }
                     };
 
-                    let malloc = match caller.get_export("malloc") {
+                    // Try proxy_on_memory_allocate first (proxy-wasm ABI), then fall back to malloc
+                    let malloc = match caller.get_export("proxy_on_memory_allocate") {
                         Some(Extern::Func(func)) => func,
-                        _ => {
-                            println!(
-                                "Error: proxy_get_header_map_pairs cannot get export \"malloc\""
-                            );
-                            println!("[vm<-host] proxy_get_header_map_pairs(...) -> (return_map_data, return_map_size) return: {:?}", Status::InternalFailure);
-                            return Status::InternalFailure as i32;
-                        }
+                        _ => match caller.get_export("malloc") {
+                            Some(Extern::Func(func)) => func,
+                            _ => {
+                                println!(
+                                    "Error: proxy_get_header_map_pairs cannot get export \"proxy_on_memory_allocate\" or \"malloc\""
+                                );
+                                println!("[vm<-host] proxy_get_header_map_pairs(...) -> (return_map_data, return_map_size) return: {:?}", Status::InternalFailure);
+                                return Status::InternalFailure as i32;
+                            }
+                        },
                     };
 
                     let (status, serial_map) = match EXPECT
@@ -752,7 +760,10 @@ fn get_hostfunc(
                         .get_expect_get_header_map_pairs(map_type)
                     {
                         (status, Some(header_map_pairs)) => (status, header_map_pairs),
-                        (Status::Ok, None) => (Status::Ok, HOST.lock().unwrap().staged.get_header_map_pairs(map_type)),
+                        (Status::Ok, None) => (
+                            Status::Ok,
+                            HOST.lock().unwrap().staged.get_header_map_pairs(map_type),
+                        ),
                         (status, None) => (status, Bytes::new()),
                     };
                     let serial_map_size = serial_map.len();
@@ -873,15 +884,19 @@ fn get_hostfunc(
                         }
                     };
 
-                    let malloc = match caller.get_export("malloc") {
+                    // Try proxy_on_memory_allocate first (proxy-wasm ABI), then fall back to malloc
+                    let malloc = match caller.get_export("proxy_on_memory_allocate") {
                         Some(Extern::Func(func)) => func,
-                        _ => {
-                            println!(
-                                "Error: proxy_get_header_map_value cannot get export \"malloc\""
-                            );
-                            println!("[vm<-host] proxy_get_header_map_value(...) -> (return_value_data, return_value_size) return: {:?}", Status::InternalFailure);
-                            return Status::InternalFailure as i32;
-                        }
+                        _ => match caller.get_export("malloc") {
+                            Some(Extern::Func(func)) => func,
+                            _ => {
+                                println!(
+                                    "Error: proxy_get_header_map_value cannot get export \"proxy_on_memory_allocate\" or \"malloc\""
+                                );
+                                println!("[vm<-host] proxy_get_header_map_value(...) -> (return_value_data, return_value_size) return: {:?}", Status::InternalFailure);
+                                return Status::InternalFailure as i32;
+                            }
+                        },
                     };
 
                     unsafe {
@@ -1229,13 +1244,17 @@ fn get_hostfunc(
                         }
                     };
 
-                    let malloc = match caller.get_export("malloc") {
+                    // Try proxy_on_memory_allocate first (proxy-wasm ABI), then fall back to malloc
+                    let malloc = match caller.get_export("proxy_on_memory_allocate") {
                         Some(Extern::Func(func)) => func,
-                        _ => {
-                            println!("Error: proxy_get_buffer_bytes cannot get export \"malloc\"");
-                            println!("[vm<-host] proxy_get_buffer_bytes(...) -> (return_buffer_data, return_buffer_size) return: {:?}", Status::InternalFailure);
-                            return Status::InternalFailure as i32;
-                        }
+                        _ => match caller.get_export("malloc") {
+                            Some(Extern::Func(func)) => func,
+                            _ => {
+                                println!("Error: proxy_get_buffer_bytes cannot get export \"proxy_on_memory_allocate\" or \"malloc\"");
+                                println!("[vm<-host] proxy_get_buffer_bytes(...) -> (return_buffer_data, return_buffer_size) return: {:?}", Status::InternalFailure);
+                                return Status::InternalFailure as i32;
+                            }
+                        },
                     };
 
                     unsafe {
@@ -1825,6 +1844,144 @@ fn get_hostfunc(
                     Status::InternalFailure
                 );
                 return Status::InternalFailure as i32;
+            },
+        )),
+
+        /* ---------------------------------- WASI Functions ---------------------------------- */
+        // Minimal WASI implementation for wasm32-wasip1 support
+        "random_get" => Some(Func::wrap(
+            store,
+            |mut caller: Caller<'_, ()>, buf: i32, buf_len: i32| -> i32 {
+                let mem = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return 1,
+                };
+                unsafe {
+                    let buffer = mem
+                        .data_mut(&mut caller)
+                        .get_unchecked_mut(buf as usize..buf as usize + buf_len as usize);
+                    use rand::Rng;
+                    rand::thread_rng().fill(buffer);
+                }
+                0
+            },
+        )),
+
+        "fd_write" => {
+            Some(Func::wrap(
+                store,
+                |mut caller: Caller<'_, ()>,
+                 fd: i32,
+                 iovs: i32,
+                 iovs_len: i32,
+                 nwritten: i32|
+                 -> i32 {
+                    let mem = match caller.get_export("memory") {
+                        Some(Extern::Memory(mem)) => mem,
+                        _ => return 8, // EBADF
+                    };
+                    let mut total = 0u32;
+                    unsafe {
+                        for i in 0..iovs_len {
+                            let base_offset = (iovs + i * 8) as usize;
+                            let len_offset = (iovs + i * 8 + 4) as usize;
+                            let base_bytes = mem
+                                .data(&caller)
+                                .get_unchecked(base_offset..base_offset + 4);
+                            let len_bytes =
+                                mem.data(&caller).get_unchecked(len_offset..len_offset + 4);
+                            let base = u32::from_le_bytes([
+                                base_bytes[0],
+                                base_bytes[1],
+                                base_bytes[2],
+                                base_bytes[3],
+                            ]) as usize;
+                            let len = u32::from_le_bytes([
+                                len_bytes[0],
+                                len_bytes[1],
+                                len_bytes[2],
+                                len_bytes[3],
+                            ]) as usize;
+                            if len > 0 {
+                                let data = mem.data(&caller).get_unchecked(base..base + len);
+                                if fd == 1 || fd == 2 {
+                                    if let Ok(s) = std::str::from_utf8(data) {
+                                        print!("{}", s);
+                                    }
+                                }
+                                total += len as u32;
+                            }
+                        }
+                        let nwritten_bytes = mem
+                            .data_mut(&mut caller)
+                            .get_unchecked_mut(nwritten as usize..nwritten as usize + 4);
+                        nwritten_bytes.copy_from_slice(&total.to_le_bytes());
+                    }
+                    return Status::Ok as i32;
+                },
+            ))
+        }
+
+        "environ_sizes_get" => {
+            Some(Func::wrap(
+                store,
+                |mut caller: Caller<'_, ()>, environc: i32, environ_buf_size: i32| -> i32 {
+                    let mem = match caller.get_export("memory") {
+                        Some(Extern::Memory(mem)) => mem,
+                        _ => return 1,
+                    };
+                    unsafe {
+                        // Return 0 environment variables and 0 buffer size
+                        let environc_bytes = mem
+                            .data_mut(&mut caller)
+                            .get_unchecked_mut(environc as usize..environc as usize + 4);
+                        environc_bytes.copy_from_slice(&0u32.to_le_bytes());
+
+                        let buf_size_bytes = mem.data_mut(&mut caller).get_unchecked_mut(
+                            environ_buf_size as usize..environ_buf_size as usize + 4,
+                        );
+                        buf_size_bytes.copy_from_slice(&0u32.to_le_bytes());
+                    }
+                    0
+                },
+            ))
+        }
+
+        "environ_get" => Some(Func::wrap(
+            store,
+            |_caller: Caller<'_, ()>, _environ: i32, _environ_buf: i32| -> i32 { 0 },
+        )),
+
+        "proc_exit" => Some(Func::wrap(
+            store,
+            |_caller: Caller<'_, ()>, exit_code: i32| {
+                // Just return and let the test continue
+                println!("[wasm] proc_exit called with code: {}", exit_code);
+            },
+        )),
+
+        "sched_yield" => Some(Func::wrap(store, |_caller: Caller<'_, ()>| -> i32 { 0 })),
+
+        "clock_time_get" => Some(Func::wrap(
+            store,
+            |mut caller: Caller<'_, ()>, _clock_id: i32, _precision: i64, time_ptr: i32| -> i32 {
+                let mem = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return 1,
+                };
+
+                let time_nanos = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos() as u64;
+
+                unsafe {
+                    let time_bytes = mem
+                        .data_mut(&mut caller)
+                        .get_unchecked_mut(time_ptr as usize..time_ptr as usize + 8);
+                    time_bytes.copy_from_slice(&time_nanos.to_le_bytes());
+                }
+                0
             },
         )),
 

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -153,14 +153,14 @@ impl Tester {
         self
     }
 
-    pub fn expect_get_current_time_nanos(&mut self) -> ExpectGetCurrentTimeNanos {
+    pub fn expect_get_current_time_nanos(&mut self) -> ExpectGetCurrentTimeNanos<'_> {
         ExpectGetCurrentTimeNanos::expecting(self)
     }
 
     pub fn expect_get_buffer_bytes(
         &mut self,
         buffer_type: Option<BufferType>,
-    ) -> ExpectGetBufferBytes {
+    ) -> ExpectGetBufferBytes<'_> {
         ExpectGetBufferBytes::expecting(self, buffer_type.map(|data| data as i32))
     }
 
@@ -178,7 +178,7 @@ impl Tester {
     pub fn expect_get_header_map_pairs(
         &mut self,
         map_type: Option<MapType>,
-    ) -> ExpectGetHeaderMapPairs {
+    ) -> ExpectGetHeaderMapPairs<'_> {
         ExpectGetHeaderMapPairs::expecting(self, map_type.map(|data| data as i32))
     }
 
@@ -197,7 +197,7 @@ impl Tester {
         &mut self,
         map_type: Option<MapType>,
         header_map_key: Option<&'static str>,
-    ) -> ExpectGetHeaderMapValue {
+    ) -> ExpectGetHeaderMapValue<'_> {
         ExpectGetHeaderMapValue::expecting(self, map_type.map(|data| data as i32), header_map_key)
     }
 
@@ -264,7 +264,7 @@ impl Tester {
         body: Option<&'static str>,
         trailers: Option<Vec<(&'static str, &'static str)>>,
         timeout: Option<u64>,
-    ) -> ExpectHttpCall {
+    ) -> ExpectHttpCall<'_> {
         ExpectHttpCall::expecting(self, upstream, headers, body, trailers, timeout)
     }
 
@@ -276,7 +276,7 @@ impl Tester {
         initial_metadata: Option<&'static [u8]>,
         request: Option<&'static [u8]>,
         timeout: Option<u64>,
-    ) -> ExpectGrpcCall {
+    ) -> ExpectGrpcCall<'_> {
         ExpectGrpcCall::expecting(
             self,
             service,
@@ -288,7 +288,10 @@ impl Tester {
         )
     }
 
-    pub fn expect_get_property(&mut self, path: Option<Vec<&'static str>>) -> ExpectGetProperty {
+    pub fn expect_get_property(
+        &mut self,
+        path: Option<Vec<&'static str>>,
+    ) -> ExpectGetProperty<'_> {
         ExpectGetProperty::expecting(self, path)
     }
 
@@ -296,7 +299,7 @@ impl Tester {
         &mut self,
         metric_type: Option<MetricType>,
         name: Option<&'static str>,
-    ) -> ExpectDefineMetric {
+    ) -> ExpectDefineMetric<'_> {
         ExpectDefineMetric::expecting(self, metric_type.map(|data| data as i32), name)
     }
 
@@ -335,7 +338,7 @@ impl Tester {
         self
     }
 
-    pub fn set_default_buffer_bytes(&mut self, buffer_type: BufferType) -> DefaultBufferBytes {
+    pub fn set_default_buffer_bytes(&mut self, buffer_type: BufferType) -> DefaultBufferBytes<'_> {
         DefaultBufferBytes::expecting(self, buffer_type as i32)
     }
 
@@ -344,13 +347,13 @@ impl Tester {
         self
     }
 
-    pub fn set_default_header_map_pairs(&mut self, map_type: MapType) -> DefaultHeaderMapPairs {
+    pub fn set_default_header_map_pairs(&mut self, map_type: MapType) -> DefaultHeaderMapPairs<'_> {
         DefaultHeaderMapPairs::expecting(self, map_type as i32)
     }
 
     /* ------------------------------------- Utility Functions ------------------------------------- */
 
-    pub fn get_expect_handle(&self) -> MutexGuard<ExpectHandle> {
+    pub fn get_expect_handle(&self) -> MutexGuard<'_, ExpectHandle> {
         self.expect.lock().unwrap()
     }
 
@@ -372,7 +375,7 @@ impl Tester {
         }
     }
 
-    pub fn get_settings_handle(&self) -> MutexGuard<HostHandle> {
+    pub fn get_settings_handle(&self) -> MutexGuard<'_, HostHandle> {
         self.defaults.lock().unwrap()
     }
 


### PR DESCRIPTION
Added:
- `random_get`
- `fd_write`
- `environ_sizes_get`
- `environ_get`
- `proc_exit`
- `clock_time_get`
- `sched_yield` *

These are listed as [supported capabilities here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-capabilityrestrictionconfig)

* This is not listed in the above, but a WASM binary with this WASI call can be successfully loaded into envoy