### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,192 +15,160 @@
 name: Rust
 
 on:
-
   pull_request:
     branches:
-    - master
+      - master
+      - kuadrant
 
   push:
     branches:
-    - master
+      - master
+      - kuadrant
 
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
-
-  licenses:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Check licenses
-      run: |
-        go get -u github.com/google/addlicense
-        export PATH=$PATH:$(go env GOPATH)/bin
-        addlicense -check .
-
   stable:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-    - name: Update Rust
-      run: rustup toolchain install stable --component clippy --component rustfmt
+      - name: Update Rust
+        run: rustup toolchain install stable --component clippy --component rustfmt
 
-    - name: Cache (generate keys)
-      run: |
-        cargo generate-lockfile
-        rustc --version | cut -d " " -f2 - > rust-toolchain
+      - name: Cache (generate keys)
+        run: |
+          cargo generate-lockfile
+          rustc --version | cut -d " " -f2 - > rust-toolchain
 
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/.crates.toml
-          ~/.cargo/.crates2.json
-          ~/.cargo/bin
-          ~/.cargo/registry
-          target
-        key: ${{ hashFiles('rust-toolchain', 'Cargo.lock') }}
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry
+            target
+          key: ${{ hashFiles('rust-toolchain', 'Cargo.lock') }}
 
-    - name: Cache (cleanup)
-      run: rm -f rust-toolchain
+      - name: Cache (cleanup)
+        run: rm -f rust-toolchain
 
-    - name: Build
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo build --release --all-targets
+      - name: Build
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo build --release --all-targets
 
-    - name: Format (rustfmt)
-      run: cargo fmt -- --check
+      - name: Format (rustfmt)
+        run: cargo fmt -- --check
 
-    - name: Format (manifest)
-      run: cargo verify-project
+      - name: Format (manifest)
+        run: cargo verify-project
 
-    - name: Package (docs)
-      run: cargo doc --no-deps
+      - name: Package (docs)
+        run: cargo doc --no-deps
 
   nightly:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-    - name: Update Rust
-      run: |
-        rustup toolchain install nightly --component clippy --component rustfmt
-        rustup default nightly
+      - name: Update Rust
+        run: |
+          rustup toolchain install nightly --component clippy --component rustfmt
+          rustup default nightly
 
-    - name: Cache (generate keys)
-      run: |
-        cargo generate-lockfile
-        rustc --version | tr " " "-" | cut -d "-" -f3,5-7 | cut -b1-18 > rust-toolchain
+      - name: Cache (generate keys)
+        run: |
+          cargo generate-lockfile
+          rustc --version | tr " " "-" | cut -d "-" -f3,5-7 | cut -b1-18 > rust-toolchain
 
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/.crates.toml
-          ~/.cargo/.crates2.json
-          ~/.cargo/bin
-          ~/.cargo/registry
-          target
-        key: ${{ hashFiles('rust-toolchain', 'Cargo.lock') }}
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry
+            target
+          key: ${{ hashFiles('rust-toolchain', 'Cargo.lock') }}
 
-    - name: Cache (cleanup)
-      run: rm -f rust-toolchain
+      - name: Cache (cleanup)
+        run: rm -f rust-toolchain
 
-    - name: Build
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo build --release --all-targets
+      - name: Build
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo build --release --all-targets
 
-    - name: Format (rustfmt)
-      run: cargo fmt -- --check
+      - name: Format (rustfmt)
+        run: cargo fmt -- --check
 
-    - name: Format (manifest)
-      run: cargo verify-project
+      - name: Format (manifest)
+        run: cargo verify-project
 
-    - name: Package (docs)
-      run: cargo doc --no-deps
+      - name: Package (docs)
+        run: cargo doc --no-deps
 
   examples:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout (test framework)
-      uses: actions/checkout@v2
+      - name: Checkout (test framework)
+        uses: actions/checkout@v6
 
-    - name: Checkout (Rust SDK)
-      uses: actions/checkout@v2
-      with:
-        repository: proxy-wasm/proxy-wasm-rust-sdk
-        path: proxy-wasm-rust-sdk
+      - name: Checkout (Rust SDK)
+        uses: actions/checkout@v6
+        with:
+          repository: proxy-wasm/proxy-wasm-rust-sdk
+          path: proxy-wasm-rust-sdk
 
-    - name: Update Rust
-      run: |
-        rustup toolchain install stable --component clippy --component rustfmt
-        rustup target add wasm32-unknown-unknown
+      - name: Update Rust
+        run: |
+          rustup toolchain install stable --component clippy --component rustfmt
+          rustup target add wasm32-unknown-unknown
 
-    - name: Cache (generate keys)
-      run: |
-        cargo generate-lockfile
-        cd proxy-wasm-rust-sdk && cargo generate-lockfile && cd ..
-        rustc --version | cut -d " " -f2 - > rust-toolchain
+      - name: Cache (generate keys)
+        run: |
+          cargo generate-lockfile
+          cd proxy-wasm-rust-sdk && cargo generate-lockfile && cd ..
+          rustc --version | cut -d " " -f2 - > rust-toolchain
 
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/.crates.toml
-          ~/.cargo/.crates2.json
-          ~/.cargo/bin
-          ~/.cargo/registry
-          target
-          proxy-wasm-rust-sdk/target
-        key: ${{ hashFiles('rust-toolchain', 'Cargo.lock', 'proxy-wasm-rust-sdk/Cargo.lock') }}
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry
+            target
+            proxy-wasm-rust-sdk/target
+          key: ${{ hashFiles('rust-toolchain', 'Cargo.lock', 'proxy-wasm-rust-sdk/Cargo.lock') }}
 
-    - name: Cache (cleanup)
-      run: rm -f rust-toolchain
+      - name: Cache (cleanup)
+        run: rm -f rust-toolchain
 
-    - name: Build (test framework)
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo build --release --all-targets
+      - name: Build (test framework)
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo build --release --all-targets
 
-    - name: Build (Rust SDK examples)
-      env:
-        RUSTFLAGS: -C link-args=-S -D warnings
-      run: cd proxy-wasm-rust-sdk && cargo build --release --examples --target=wasm32-unknown-unknown && cd ..
+      - name: Build (Rust SDK examples)
+        env:
+          RUSTFLAGS: -C link-args=-S -D warnings
+        run: cd proxy-wasm-rust-sdk && cargo build --release --examples --target=wasm32-unknown-unknown && cd ..
 
-    - name: Test (hello_world)
-      run: target/release/examples/hello_world proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/hello_world.wasm
+      - name: Test (hello_world)
+        run: target/release/examples/hello_world proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/hello_world.wasm
 
-    - name: Test (http_auth_random)
-      run: target/release/examples/http_auth_random proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/http_auth_random.wasm -a
+      - name: Test (http_auth_random)
+        run: target/release/examples/http_auth_random proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/http_auth_random.wasm -a
 
-    - name: Test (http_headers)
-      run: target/release/examples/http_headers proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/http_headers.wasm -a
-
-  outdated:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Run cargo outdated
-      run: cargo outdated --exit-code 1
-
-  audit:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Run cargo audit
-      run: |
-        cargo generate-lockfile
-        cargo audit
+      - name: Test (http_headers)
+        run: target/release/examples/http_headers proxy-wasm-rust-sdk/target/wasm32-unknown-unknown/release/examples/http_headers.wasm -a


### PR DESCRIPTION
The actions are failing on merge to master and nightly due to deprecated `actions/cache@v2`

This updates it but we could also just disable the actions running potentially as I'm not sure how much we gain from having them run..